### PR TITLE
feat: add Didomi CMP two-step support for cdon.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "eslint src/**/*.ts --fix",
     "lint:check": "eslint src/**/*.ts --max-warnings 0",
     "prebuild": "npm run lint:check",
-    "test": "jest",
+    "test": "jest --forceExit",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:coverage:open": "jest --coverage && npm run open:coverage",

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -64,13 +64,15 @@ class CookieDecliner {
       return true;
     }
     
-    for (const { selector } of this.declineSelectors) {
+    for (const { selector, isExpandButton } of this.declineSelectors) {
       try {
         const elements = DOMUtils.findElementsBySelector(selector);
         for (const element of elements) {
-          if (this.processElement(element)) {
-            console.log('Cookie Decliner: Successfully declined cookies');
-            return true;
+          if (this.processElement(element, isExpandButton)) {
+            if (!isExpandButton) {
+              console.log('Cookie Decliner: Successfully declined cookies');
+            }
+            return !isExpandButton;
           }
         }
       } catch (error) {
@@ -81,7 +83,7 @@ class CookieDecliner {
     return false;
   }
 
-  private processElement(element: Element): boolean {
+  private processElement(element: Element, isExpandButton = false): boolean {
     if (!DOMUtils.isElementVisible(element)) {
       return false;
     }
@@ -96,7 +98,12 @@ class CookieDecliner {
     
     DOMUtils.clickElement(element);
     this.processed.add(element);
-    this.markConsentProcessed();
+
+    if (isExpandButton) {
+      console.log('Cookie Decliner: Clicked expand button, waiting for preferences panel');
+    } else {
+      this.markConsentProcessed();
+    }
     
     return true;
   }

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -2,6 +2,8 @@
 export interface CookieSelector {
   selector: string;
   description: string;
+  /** When true, clicking this button opens a deeper preferences panel — do not mark consent as processed */
+  isExpandButton?: boolean;
 }
 
 export interface LanguageConfig {
@@ -53,6 +55,14 @@ export const LANGUAGE_CONFIGS: LanguageConfig[] = [
 
 // Framework-specific selectors
 export const FRAMEWORK_SELECTORS: CookieSelector[] = [
+  // Didomi CMP (used by cdon.com)
+  // Step 1: Open preferences panel — do NOT mark consent as processed
+  { selector: '#didomi-notice-learn-more-button', description: 'Didomi: Open preferences panel (step 1)', isExpandButton: true },
+  { selector: 'button.didomi-learn-more-button', description: 'Didomi: Learn more button (step 1)', isExpandButton: true },
+
+  // Step 2: Decline all in preferences panel
+  { selector: '#btn-toggle-disagree', description: 'Didomi: Decline all (step 2)' },
+
   // Cookie Information specific selectors (hjemla.no uses this)
   { selector: 'button.coi-consent-banner__decline-button', description: 'Cookie Information: Decline button' },
   { selector: '.coi-consent-banner__decline-button', description: 'Cookie Information: Decline element' },

--- a/tests/unit/didomi.test.ts
+++ b/tests/unit/didomi.test.ts
@@ -1,0 +1,136 @@
+import { FRAMEWORK_SELECTORS, getAllDeclineSelectors } from '../../src/selectors';
+import { DOMUtils } from '../../src/dom-utils';
+
+describe('Didomi CMP two-step flow', () => {
+  describe('selectors', () => {
+    it('includes step-1 expand button selector for #didomi-notice-learn-more-button', () => {
+      const selector = FRAMEWORK_SELECTORS.find(s => s.selector === '#didomi-notice-learn-more-button');
+      expect(selector).toBeDefined();
+      expect(selector?.isExpandButton).toBe(true);
+    });
+
+    it('includes step-1 expand button selector for button.didomi-learn-more-button', () => {
+      const selector = FRAMEWORK_SELECTORS.find(s => s.selector === 'button.didomi-learn-more-button');
+      expect(selector).toBeDefined();
+      expect(selector?.isExpandButton).toBe(true);
+    });
+
+    it('includes step-2 decline selector for #btn-toggle-disagree', () => {
+      const selector = FRAMEWORK_SELECTORS.find(s => s.selector === '#btn-toggle-disagree');
+      expect(selector).toBeDefined();
+      expect(selector?.isExpandButton).toBeFalsy();
+    });
+
+    it('step-2 decline selector is listed after step-1 expand selectors in the combined list', () => {
+      const all = getAllDeclineSelectors();
+      const expandIdx = all.findIndex(s => s.selector === '#didomi-notice-learn-more-button');
+      const declineIdx = all.findIndex(s => s.selector === '#btn-toggle-disagree');
+      expect(expandIdx).toBeGreaterThanOrEqual(0);
+      expect(declineIdx).toBeGreaterThanOrEqual(0);
+      expect(declineIdx).toBeGreaterThan(expandIdx);
+    });
+  });
+
+  describe('step-1 expand button interaction', () => {
+    let learnMoreBtn: HTMLButtonElement;
+
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <div id="didomi-host">
+          <div class="didomi-popup-container">
+            <p>Cookies og lignende teknologier</p>
+            <div id="buttons">
+              <button id="didomi-notice-learn-more-button" class="didomi-learn-more-button" style="width: 120px; height: 40px;">
+                <span>Les mer →</span>
+              </button>
+              <button id="didomi-notice-agree-button" style="width: 120px; height: 40px;">
+                <span>Godta og lukk</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      `;
+      learnMoreBtn = document.getElementById('didomi-notice-learn-more-button') as HTMLButtonElement;
+    });
+
+    afterEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    it('expand button is found by DOMUtils.findElementsBySelector', () => {
+      const results = DOMUtils.findElementsBySelector('#didomi-notice-learn-more-button');
+      expect(results).toHaveLength(1);
+      expect(results[0]).toBe(learnMoreBtn);
+    });
+
+    it('expand button is visible', () => {
+      expect(DOMUtils.isElementVisible(learnMoreBtn)).toBe(true);
+    });
+
+    it('expand button passes cookie-related validation', () => {
+      expect(DOMUtils.isCookieRelatedButton(learnMoreBtn)).toBe(true);
+    });
+  });
+
+  describe('step-2 decline button interaction', () => {
+    let declineAllBtn: HTMLButtonElement;
+
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <div class="didomi-consent-popup-preferences-purposes">
+          <div class="didomi-consent-popup-footer">
+            <div class="didomi-buttons-all-container">
+              <button id="btn-toggle-disagree" aria-label="Avslå alle: Avslå databehandlingen vår og lukk" style="width: 120px; height: 40px;">
+                <span>Avslå alle</span>
+              </button>
+              <button id="btn-toggle-agree" aria-label="Godta alle: Godta databehandlingen vår og lukk" style="width: 120px; height: 40px;">
+                <span>Godta alle</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      `;
+      declineAllBtn = document.getElementById('btn-toggle-disagree') as HTMLButtonElement;
+    });
+
+    afterEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    it('decline-all button is found by DOMUtils.findElementsBySelector', () => {
+      const results = DOMUtils.findElementsBySelector('#btn-toggle-disagree');
+      expect(results).toHaveLength(1);
+      expect(results[0]).toBe(declineAllBtn);
+    });
+
+    it('decline-all button is visible', () => {
+      expect(DOMUtils.isElementVisible(declineAllBtn)).toBe(true);
+    });
+
+    it('decline-all button passes cookie-related validation', () => {
+      expect(DOMUtils.isCookieRelatedButton(declineAllBtn)).toBe(true);
+    });
+
+    it('decline-all button text is recognised via :contains selector', () => {
+      const results = DOMUtils.findElementsBySelector('button:contains("Avslå alle")');
+      expect(results.some(el => el === declineAllBtn)).toBe(true);
+    });
+  });
+
+  describe('isExpandButton flag contract', () => {
+    it('no standard decline selectors have isExpandButton set to true', () => {
+      const falsePositives = FRAMEWORK_SELECTORS.filter(
+        s => s.isExpandButton === true && !s.description.includes('step 1')
+      );
+      expect(falsePositives).toHaveLength(0);
+    });
+
+    it('all selectors without isExpandButton treat the flag as falsy', () => {
+      const all = getAllDeclineSelectors();
+      const withoutFlag = all.filter(s => !s.isExpandButton);
+      for (const s of withoutFlag) {
+        expect(Boolean(s.isExpandButton)).toBe(false);
+      }
+    });
+  });
+});


### PR DESCRIPTION
CDON uses Didomi CMP which requires two interactions to decline:
1. Click 'Les mer' to open the preferences panel
2. Click 'Avsla alle' to decline all cookies

Add isExpandButton flag to CookieSelector interface. Expand buttons are clicked without marking consent as processed, keeping the MutationObserver alive to detect the preferences panel and find the final decline button.

Also add --forceExit to npm test to avoid hanging on pre-existing open handles from MutationObserver/timer teardown.